### PR TITLE
adds help with Microsoft WSL

### DIFF
--- a/ssh_client.py
+++ b/ssh_client.py
@@ -18,6 +18,12 @@ BASH_PROFILE_PATH = '~/.bash_profile'
 DEF_KNOWN_HOSTS_PATH = '~/.ssh/known_hosts'
 DEF_SSH_CONF_PATH = '~/.ssh/config'
 
+### parts for handling browser OPEN if running in WSL1 ###
+# example:  BROWSER_PATH = '/mnt/c/Program\ Files\ \(x86\)/Google/Chrome/Application/chrome.exe'
+# example: BROWSER_PATH = '/mnt/c/Users/<<username>>/AppData/Local/Vivaldi/Application/vivaldi.exe'
+BROWSER_PATH = '/mnt/c/Path/to/browser.exe'
+isWSL = str(subprocess.check_output(['uname', '-r']))
+
 USAGE = """\
 Usage: pritunl-ssh [command]
 
@@ -32,7 +38,10 @@ Commands:
   clear-strict-host    Remove strict host checking configuration changes
   clear-bastion-host   Remove bastion host configuration changes
   register-smart-card  Register the current Smart Card with Pritunl Zero
-  gpg-reset            Reset GPG Smart Card agent"""
+  gpg-reset            Reset GPG Smart Card agent
+
+Note: Links may not auto-load in your browser if using Microsoft WSL
+  set BROWSER_PATH variable in /usr/bin/pritunl-ssh (example provided)"""
 
 conf_zero_server = None
 conf_pub_key_path = None
@@ -543,7 +552,12 @@ if '--register-smart-card' in sys.argv[1:] or \
         )
     except:
         try:
-            subprocess.Popen(['open', device_url])
+            if "Microsoft" in isWSL and os.path.isfile(BROWSER_PATH):
+                subprocess.Popen([BROWSER_PATH, device_url])
+            else:
+                if "Microsoft" in isWSL:
+                    print('Default browser not defined for WSL')
+                subprocess.Popen(['open', device_url])
         except:
             pass
 
@@ -650,7 +664,12 @@ try:
     )
 except:
     try:
-        subprocess.Popen(['open', token_url])
+        if "Microsoft" in isWSL and os.path.isfile(BROWSER_FILE):
+            subprocess.Popen([BROWSER_PATH, token_url])
+        else:
+            if "Microsoft" in isWSL:
+                print('Default browser not defined for WSL')
+            subprocess.Popen(['open', token_url])
     except:
         pass
 


### PR DESCRIPTION
adds checks for Microsoft WSL kernel to help handle browser URL loading. Depends on: define BROWSER_PATH in /usr/bin/pritunl-ssh