### PR TITLE
use raw string for browser path

### DIFF
--- a/ssh_client.py
+++ b/ssh_client.py
@@ -17,7 +17,7 @@ CONF_PATH = SSH_DIR + '/pritunl-zero.json'
 BASH_PROFILE_PATH = '~/.bash_profile'
 DEF_KNOWN_HOSTS_PATH = '~/.ssh/known_hosts'
 DEF_SSH_CONF_PATH = '~/.ssh/config'
-BROWSER_PATH = '/mnt/c/Program\ Files\ \(x86\)/Google/Chrome/Application/chrome.exe'
+BROWSER_PATH = r'/mnt/c/Program\ Files\ \(x86\)/Google/Chrome/Application/chrome.exe'
 
 USAGE = """\
 Usage: pritunl-ssh [command]


### PR DESCRIPTION
resolves the following warnings:

```
/opt/homebrew/bin/pritunl-ssh:20: SyntaxWarning: invalid escape sequence '\ '
  BROWSER_PATH = '/mnt/c/Program\ Files\ \(x86\)/Google/Chrome/Application/chrome.exe'
/opt/homebrew/bin/pritunl-ssh:20: SyntaxWarning: invalid escape sequence '\ '
  BROWSER_PATH = '/mnt/c/Program\ Files\ \(x86\)/Google/Chrome/Application/chrome.exe'
```